### PR TITLE
Fix upgrading of development dependencies for Python 3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install_devel:
 	pip3 install ".[devel]"
 
 install_devel_edge: install_devel
-	pip3 install --upgrade `python -c "from importlib.metadata import requires; print(' '.join(r.split(' ')[0] for r in requires('python-style') if 'devel' in r))"`
+	tools/upgrade_dependencies.py
 
 clean:
 	rm -rf .coverage .mypy_cache .pytest_cache

--- a/tools/upgrade_dependencies.py
+++ b/tools/upgrade_dependencies.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+"""Upgrade all development dependencies."""
+
+import sys
+from subprocess import call
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import requires
+else:
+    from importlib_metadata import requires
+
+DEPENDENCIES = " ".join(r.split(" ")[0] for r in (requires("python-style") or []) if "devel" in r)
+
+call(f"pip3 install --upgrade {DEPENDENCIES}", shell=True)


### PR DESCRIPTION
This will fix the edge tests which failed last night: https://github.com/Componolit/python-style/runs/4064979807?check_suite_focus=true.