### PR TITLE
Add support for using pyproject-flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E203, E501, E741, W503

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ check_isort:
 	isort --check --diff $(python-packages)
 
 check_flake8:
-	flake8 $(python-packages)
+	pflake8 $(python-packages)
 
 check_pylint:
 	pylint $(python-packages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,7 @@ exclude_lines = [
     'raise NotImplementedError',
     'return NotImplemented',
 ]
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = "E203, E501, E741, W503"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ devel =
     mypy ==0.910
     pydocstyle >=6, <6.2
     pylint >=2.8.3, <2.12
+    pyproject-flake8 ==0.0.1a2
     pytest >=6.2.4, <6.3
     pytest-cov >=2.12.1, <2.13
     pytest-xdist >=2.3.0, <2.5


### PR DESCRIPTION
The `pyproject-flake8` wrapper [1] allows for having the flake8 configuration in pyproject.toml. I'm using it for the CWE tool I'm building. Not sure we want to adopt it for RecordFlux - it's an alpha release which hasn't been updated for almost a year. However, I found no issues with it so far. @treiher What do you think?

[1] https://pypi.org/project/pyproject-flake8/