### PR TITLE
Enable use of `setuptools_scm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ['setuptools', 'wheel']
+requires = ['setuptools', 'wheel', 'setuptools_scm[toml]>=6.2']
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Required by Componolit/RecordFlux#1003.