### PR TITLE
Add minimum required version of `setuptools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'setuptools_scm[toml]>=6.2']
+requires = ['setuptools>=45', 'setuptools_scm[toml]>=6.2', 'wheel']
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Using an older version of `setuptools` leads to an error (see also Componolit/RecordFlux#1107):

```console
ERROR: setuptools==44.0.0 is used in combination with setuptools_scm>=6.x

Your build configuration is incomplete and previously worked by accident!
setuptools_scm requires setuptools>=45

[...]
```