### PR TITLE
Recordflux issue 1109: Fix anonymous boolean pylint plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 VERBOSE ?= @
+TMPDIR := $(shell mktemp -d)
 
 python-packages := python_style tests
 
-.PHONY: check check_black check_isort check_flake8 check_pylint check_mypy check_pydocstyle format test install install_devel install_edge clean
+.PHONY: check check_black check_isort check_flake8 check_pylint check_mypy check_pydocstyle format test test_unit test_integration install install_devel install_edge clean
 
 all: check test
 
@@ -30,8 +31,17 @@ format:
 	black -l 100 $(python-packages)
 	isort $(python-packages)
 
-test:
-	python3 -m pytest -n$(shell nproc) -vv tests
+test: test_unit test_integration
+
+test_unit:
+	python3 -m pytest -vv tests
+
+$(TMPDIR)/bin/pylint:
+	python3 -m venv $(TMPDIR)
+	$(TMPDIR)/bin/pip install pylint .[devel]
+
+test_integration: $(TMPDIR)/bin/pylint
+	$< tests/data/pylint_boolean_argument_invalid.py
 
 install:
 	pip3 install --force-reinstall .

--- a/python_style/pylint_checker.py
+++ b/python_style/pylint_checker.py
@@ -1,19 +1,16 @@
 import astroid
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 
 
 class NamedBooleanArgumentsChecker(BaseChecker):  # type: ignore[misc]
-    __implements__ = IAstroidChecker
 
     name = "named-boolean-arguments"
-    priority = -1
     msgs = {
-        "C0001": {
+        "C0001": (
             "Anonymous boolean argument",
             "anon-bool-arg",
             "Boolean arguments must be passed as keywords",
-        }
+        )
     }
 
     def visit_call(self, node: astroid.Call) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = python-style
-version = 0.1.0
+version = 0.1.1
 license = AGPL-3.0
 description = Linter configs and custom checkers
 url = https://github.com/Componolit/python-style

--- a/tests/data/pylint_boolean_argument_invalid.py
+++ b/tests/data/pylint_boolean_argument_invalid.py
@@ -1,0 +1,30 @@
+# pylint: enable=useless-suppression
+
+
+class SomeClass:
+    def __init__(self, arg1: bool, arg2: bool):
+        pass
+
+
+def func(arg1: bool, arg2: bool) -> bool:
+    return arg1 and arg2
+
+
+def use_func_valid() -> None:
+    func(arg1=True, arg2=False)
+
+
+def use_func_invalid() -> None:
+    # As we enable useless supression above, pylinting this function only succeeds if an anonymous
+    # boolean argument had been detected below (otherwise we will get a useless supression error).
+    # pylint: disable-next=anon-bool-arg
+    func(True, False)
+
+
+def use_class_valid() -> None:
+    SomeClass(arg1=True, arg2=False)
+
+
+def use_class_invalid() -> None:
+    # pylint: disable-next=anon-bool-arg
+    SomeClass(True, False)


### PR DESCRIPTION
Updated our `pylint` plugin (the `pylint` version that we are using was already emitting a deprecation warning). I also added a command-line integration test for the plugin which should make sure that it's actually executed. However, I found no real root-cause for Componolit/RecordFlux#1109. Maybe that was due to the API change...