### PR TITLE
Use shorter traceback format for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ ignore = [
 ]
 
 [tool.pytest.ini_options]
+addopts = '--tb=short'
 filterwarnings = [
     'ignore:visit_NameConstant is deprecated; add visit_Constant:PendingDeprecationWarning',
     'ignore:visit_Str is deprecated; add visit_Constant:PendingDeprecationWarning',


### PR DESCRIPTION
The short traceback format is usually sufficient and clearer than the long traceback format which is used by default.

## Example

### Short traceback format

```console
___________________________________ test_provability[session_sequence_append_head] ___________________________________
tests/integration/feature_test.py:128: in test_provability
    assert_provable_code(model, integration, tmp_path, main=MAIN, units=[*units, *config.prove])
tests/utils.py:219: in assert_provable_code
    run([*gnatprove, "-u", unit])
tests/utils.py:209: in run
    p = subprocess.run(command, cwd=tmp_path, check=False, stderr=subprocess.PIPE)
../../e3/lib/python3.9/subprocess.py:505: in run
    with Popen(*popenargs, **kwargs) as process:
../../e3/lib/python3.9/subprocess.py:951: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
../../e3/lib/python3.9/subprocess.py:1821: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'gnatprove'
```

### Long traceback format (default)

(I had to shorten the example because GitHub limits the PR body to 65536 characters.)

```console
___________________________________ test_provability[session_sequence_append_head] ___________________________________                                                                                                
                                                                                                                                                                                                                      
feature = 'session_sequence_append_head'                                                                                                                                                                              
tmp_path = PosixPath('/tmp/pytest-of-reiher/pytest-8/test_provability_session_seque0')                                                                                                                                
                                                                                                                                                                                                                      
    @pytest.mark.verification                                                                                                                                                                                         
    @pytest.mark.parametrize("feature", [f.name for f in FEATURES])                                                                                                                                                   
    def test_provability(feature: str, tmp_path: Path) -> None:                                                                                                                                                       
        config = get_config(feature)                                                                                                                                                                                  
        if config.prove is None:                                                                                                                                                                                      
            pytest.skip()                                                                                                                                                                                             
        model, integration = create_model(feature)                                                                                                                                                                    
        units = []                                                                                                                                                                                                    
        if model.sessions:                                                                                                                                                                                            
            assert len(model.sessions) == 1                                                                                                                                                                           
            assert model.sessions[0].identifier == ID("Test::Session")                                                                                                                                                
            units = ["main", "lib", "rflx-test-session"]                                                                                                                                                              
            create_complement(config, feature, tmp_path)                                                                                                                                                              
>       assert_provable_code(model, integration, tmp_path, main=MAIN, units=[*units, *config.prove])                                                                                                                  
                                                                                                                                                                                                                      
tests/integration/feature_test.py:128:                                                                                                                                                                                
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                 
                                                                                                                                                                                                                      
model =                                                                                                                                                                                                               
    Model(types=[                                                                                                                                                                                                     
              Enumeration(identifier=ID("__BUILTINS__::Boolean"),                                                                                                                                                     
                          literal...  #       end Reply;                                                                                                                                                              
    #                                                                                                                                                                                                                 
    #       state Terminated is null state;                                                                                                                                                                           
    #    end Session;                                                                                                                                                                                                 
    #                                                                                                                                                                                                                 
    # end Test;                                                                                                                                                                                                       
                                                                                                                                                                                                                      
integration = <rflx.integration.Integration object at 0x7fd18bd9c7c0>                                                                                                                                                 
tmp_path = PosixPath('/tmp/pytest-of-reiher/pytest-8/test_provability_session_seque0'), main = 'main.adb'                                                                                                             
prefix = None, units = ['main', 'lib', 'rflx-test-session']                                                                                                                                                           
                                                                                                                                                                                                                      
    def assert_provable_code(                                                                                                                                                                                         
        model: Model,                                                                                                                                                                                                 
        integration: Integration,                                                                                                                                                                                     
        tmp_path: pathlib.Path,                                                                                                                                                                                       
        main: str = None,                                                                                                                                                                                             
        prefix: str = None,                                                                                                                                                                                           
        units: Sequence[str] = None,                                                                                                                                                                                  
    ) -> None:                                                                                                                                                                                                        
        _create_files(tmp_path, model, integration, main, prefix)                                                                                                                                                     
                                                                                                                                                                                                                      
        def run(command: Sequence[str]) -> None:                                                                                                                                                                      
            p = subprocess.run(command, cwd=tmp_path, check=False, stderr=subprocess.PIPE)                                                                                                                            
            if p.returncode:                                                                                                                                                                                          
                raise AssertionError(                                                                                                                                                                                 
                    f"non-zero exit status {p.returncode}\n{p.stderr.decode('utf-8')}",                                                                                                                               
                )                                                                                                                                                                                                     
                                                                                                                                                                                                                      
        gnatprove = ["gnatprove", "-Ptest"]                                                                                                                                                                           
                                                                                                                                                                                                                      
        if units:                                                                                                                                                                                                     
            for unit in units:                                                                                                                                                                                        
>               run([*gnatprove, "-u", unit])                                                                                                                                                                         
                                                 tests/utils.py:219:                                                                                                                                                                                                   
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                 
                                                                                                                                                                                                                      
command = ['gnatprove', '-Ptest', '-u', 'main']                                                                                                                                                                       
                                                                                                                                                                                                                      
    def run(command: Sequence[str]) -> None:                                                                                                                                                                          
>       p = subprocess.run(command, cwd=tmp_path, check=False, stderr=subprocess.PIPE)                                                                                                                                
                                                                                                                                                                                                                      
tests/utils.py:209:                                                                                                                                                                                                   
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                 
                                                                                                                                                                                                                      
input = None, capture_output = False, timeout = None, check = False                                                                                                                                                   
popenargs = (['gnatprove', '-Ptest', '-u', 'main'],)                                                                                                                                                                  
kwargs = {'cwd': PosixPath('/tmp/pytest-of-reiher/pytest-8/test_provability_session_seque0'), 'stderr': -1}                                                                                                           
                                                                                                                                                                                                                      
    def run(*popenargs,                                                                                                                                                                                               
            input=None, capture_output=False, timeout=None, check=False, **kwargs):                                                                                                                                   
        """Run command with arguments and return a CompletedProcess instance.                                                                                                                                         
                                                                                                                                                                                                                      
        The returned instance will have attributes args, returncode, stdout and                                                                                                                                       
        stderr. By default, stdout and stderr are not captured, and those attributes                                                                                                                                  
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.                                                                                                                                   
                                                                                                                                                                                                                      
        If check is True and the exit code was non-zero, it raises a                                                                                                                                                  
        CalledProcessError. The CalledProcessError object will have the return code                                                                                                                                   
        in the returncode attribute, and output & stderr attributes if those streams                                                                                                                                  
        were captured.                                                                                                                                                                                                
                                                                                                                                                                                                                      
        If timeout is given, and the process takes too long, a TimeoutExpired                                                                                                                                         
        exception will be raised.                                                                                                                                                                                     
                                                                                                                                                                                                                      
        There is an optional argument "input", allowing you to                                                                                                                                                        
        pass bytes or a string to the subprocess's stdin.  If you use this argument                                                                                                                                   
        you may not also use the Popen constructor's "stdin" argument, as                                                                                                                                             
        it will be used internally.                                                                                                                                                                                   
                                                                                                                                                                                                                      
        By default, all communication is in bytes, and therefore any "input" should                                                                                                                                   
        be bytes, and the stdout and stderr will be bytes. If in text mode, any                                                                                                                                       
        "input" should be a string, and stdout and stderr will be strings decoded                                                                                                                                     
        according to locale encoding, or by "encoding" if set. Text mode is                                                                                                                                           
        triggered by setting any of text, encoding, errors or universal_newlines.                                                                                                                                     
                                                                                                                                                                                                                      
        The other arguments are the same as for the Popen constructor.                                                                                                                                                
        """                                                                                                                                                                                                           
        if input is not None:                                                                                                                                                                                         
            if kwargs.get('stdin') is not None:                                                                                                                                                                       
                raise ValueError('stdin and input arguments may not both be used.')                                                                                                                                   
            kwargs['stdin'] = PIPE                                                                                                                                                                                    
                                                                                                                                                                                                                      
        if capture_output:                                                                                                                                                                                            
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:                                                                                                                                  
                raise ValueError('stdout and stderr arguments may not be used '                                                                                                                                       
                                 'with capture_output.')                                                                                                                                                              
            kwargs['stdout'] = PIPE                                                                                                                                                                                   
            kwargs['stderr'] = PIPE                                                                                                                                                                                   
                                                                                                                                                                                                                      
>       with Popen(*popenargs, **kwargs) as process:                                                                                                                                                                  
                                                                                                                                                                                                                      
../../e3/lib/python3.9/subprocess.py:505:                                                                                                                                                                             
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                 
                                                                                                                                                                                                                      
self = <Popen: returncode: 255 args: ['gnatprove', '-Ptest', '-u', 'main']>                                                                                                                                           
args = ['gnatprove', '-Ptest', '-u', 'main'], bufsize = -1, executable = None, stdin = None, stdout = None                                                                                                            
stderr = -1, preexec_fn = None, close_fds = True, shell = False                                                                                                                                                       
cwd = PosixPath('/tmp/pytest-of-reiher/pytest-8/test_provability_session_seque0'), env = None                                                                                                                         
universal_newlines = None, startupinfo = None, creationflags = 0, restore_signals = True, start_new_session = False                                                                                                   
pass_fds = ()                                                                                                                                                                                                         
                                                                                                                                                                                                                      
[...]                                                                                                                                                     
                                                                                                                                                                                                                      
../../e3/lib/python3.9/subprocess.py:951:                                                                                                                                                                             
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                                                                                 
                                                                                                                                                                                                                      
self = <Popen: returncode: 255 args: ['gnatprove', '-Ptest', '-u', 'main']>                                                                                                                                           
args = ['gnatprove', '-Ptest', '-u', 'main'], executable = b'gnatprove', preexec_fn = None, close_fds = True                                                                                                          
pass_fds = (), cwd = PosixPath('/tmp/pytest-of-reiher/pytest-8/test_provability_session_seque0'), env = None                                                                                                          
startupinfo = None, creationflags = 0, shell = False, p2cread = -1, p2cwrite = -1, c2pread = -1, c2pwrite = -1                                                                                                        
errread = 19, errwrite = 20, restore_signals = True, gid = None, gids = None, uid = None, umask = -1                                                                                                                  
start_new_session = False                                                                                  
                                                                                                           
    def _execute_child(self, args, executable, preexec_fn, close_fds,                                                                                                                                                 
                       pass_fds, cwd, env,                                                                                                                                                                            
                       startupinfo, creationflags, shell,                                                  
                       p2cread, p2cwrite,                                                                  
                       c2pread, c2pwrite,                                                                  
                       errread, errwrite,                                                                                                                                                                             
                       restore_signals,                                                                                                                                                                               
                       gid, gids, uid, umask,                                                                                                                                                                         
                       start_new_session):                                                                                                                                                                            
        """Execute program (POSIX version)"""                                                                                                                                                                         
                                              
        if isinstance(args, (str, bytes)):
            args = [args]
        elif isinstance(args, os.PathLike):
            if shell:
                raise TypeError('path-like args is not allowed when '
                                'shell is true')
            args = [args]
        else:
            args = list(args)
    
        if shell:
            # On Android the default shell is at '/system/bin/sh'.
            unix_shell = ('/system/bin/sh' if
                      hasattr(sys, 'getandroidapilevel') else '/bin/sh')
            args = [unix_shell, "-c"] + args
            if executable:
                args[0] = executable
    
        if executable is None:
            executable = args[0]
    
        sys.audit("subprocess.Popen", executable, args, cwd, env)
    
        if (_USE_POSIX_SPAWN
                and os.path.dirname(executable)
                and preexec_fn is None
                and not close_fds
                and not pass_fds
                and cwd is None
                and (p2cread == -1 or p2cread > 2)
                and (c2pwrite == -1 or c2pwrite > 2)
                and (errwrite == -1 or errwrite > 2)
                and not start_new_session
                and gid is None
                and gids is None
                and uid is None
                and umask < 0):
            self._posix_spawn(args, executable, env, restore_signals,
                              p2cread, p2cwrite,
                              c2pread, c2pwrite,
                              errread, errwrite)
            return
    
        orig_executable = executable
    
        # For transferring possible exec failure from child to parent.
        # Data format: "exception name:hex errno:description"
        # Pickle is not used; it is complex and involves memory allocation.
        errpipe_read, errpipe_write = os.pipe()
        # errpipe_write must not be in the standard io 0, 1, or 2 fd range.
        low_fds_to_close = []
        while errpipe_write < 3:
            low_fds_to_close.append(errpipe_write)
            errpipe_write = os.dup(errpipe_write)
        for low_fd in low_fds_to_close:
            os.close(low_fd)
        try:
            try:
                # We must avoid complex work that could involve
                # malloc or free in the child process to avoid
                # potential deadlocks, thus we do all this here.
                # and pass it to fork_exec()
    
                if env is not None:
                    env_list = []
                    for k, v in env.items():
                        k = os.fsencode(k)
                        if b'=' in k:
                            raise ValueError("illegal environment variable name")
                        env_list.append(k + b'=' + os.fsencode(v))
                else:
                    env_list = None  # Use execv instead of execve.
                executable = os.fsencode(executable)
                if os.path.dirname(executable):
                    executable_list = (executable,)
                else:
                    # This matches the behavior of os._execvpe().
                    executable_list = tuple(
                        os.path.join(os.fsencode(dir), executable)
                        for dir in os.get_exec_path(env))
                fds_to_keep = set(pass_fds)
                fds_to_keep.add(errpipe_write)
                self.pid = _posixsubprocess.fork_exec(
                        args, executable_list,
                        close_fds, tuple(sorted(map(int, fds_to_keep))),
                        cwd, env_list,
                        p2cread, p2cwrite, c2pread, c2pwrite,
                        errread, errwrite,
                        errpipe_read, errpipe_write,
                        restore_signals, start_new_session,
                        gid, gids, uid, umask,
                        preexec_fn)
                self._child_created = True
            finally:
                # be sure the FD is closed no matter what
                os.close(errpipe_write)
    
            self._close_pipe_fds(p2cread, p2cwrite,
                                 c2pread, c2pwrite,
                                 errread, errwrite)
    
            # Wait for exec to fail or succeed; possibly raising an
            # exception (limited in size)
            errpipe_data = bytearray()
            while True:
                part = os.read(errpipe_read, 50000)
                errpipe_data += part
                if not part or len(errpipe_data) > 50000:
                    break
        finally:
            # be sure the FD is closed no matter what
            os.close(errpipe_read)
    
        if errpipe_data:
            try:
                pid, sts = os.waitpid(self.pid, 0)
                if pid == self.pid:
                    self._handle_exitstatus(sts)
                else:
                    self.returncode = sys.maxsize
            except ChildProcessError:
                pass
    
            try:
                exception_name, hex_errno, err_msg = (
                        errpipe_data.split(b':', 2))
                # The encoding here should match the encoding
                # written in by the subprocess implementations
                # like _posixsubprocess
                err_msg = err_msg.decode()
            except ValueError:
                exception_name = b'SubprocessError'
                hex_errno = b'0'
                err_msg = 'Bad exception data from child: {!r}'.format(
                              bytes(errpipe_data))
            child_exception_type = getattr(
                    builtins, exception_name.decode('ascii'),
                    SubprocessError)
            if issubclass(child_exception_type, OSError) and hex_errno:
                errno_num = int(hex_errno, 16)
                child_exec_never_called = (err_msg == "noexec")
                if child_exec_never_called:
                    err_msg = ""
                    # The error must be from chdir(cwd).
                    err_filename = cwd
                else:
                    err_filename = orig_executable
                if errno_num != 0:
                    err_msg = os.strerror(errno_num)
>               raise child_exception_type(errno_num, err_msg, err_filename)
E               FileNotFoundError: [Errno 2] No such file or directory: 'gnatprove'

../../e3/lib/python3.9/subprocess.py:1821: FileNotFoundError
```